### PR TITLE
Set file encoding to UTF-8

### DIFF
--- a/src/background_js_min.js
+++ b/src/background_js_min.js
@@ -54,7 +54,7 @@
                     E(a, "dict", d);
                     if ("en" == t.language) {
                         var data = H(a);
-                        F((data && data.prettyQuery || c).replace(/¡¤/g, ""), function (a) {
+                        F((data && data.prettyQuery || c).replace(/Â·/g, ""), function (a) {
                             E(a, "translate", d)
                         }, t.language);
                     }
@@ -64,7 +64,7 @@
                 "en" != t.language && google.language.define(c, "en", "en", function (a) {
                     E(a, "enDict", d);
                     var data = H(a);
-                    F((data && data.prettyQuery || c).replace(/¡¤/g, ""), function (a) {
+                    F((data && data.prettyQuery || c).replace(/Â·/g, ""), function (a) {
                         E(a, "translate", d)
                     }, d.request.type == "fetch_raw" ? t.language: "");
                 }, {
@@ -177,7 +177,7 @@
                     var limit = 10;
 
                     e = "";
-                    
+
                     if (c && c.dict && 0 < c.dict.length) {
                         e = '<h3 class="dct-tl">Translated Definitions</h3>';
                         f = 0;
@@ -392,7 +392,7 @@
             return ""
         }, K = function (a) {
             if (!a || 0 == a.length) return k;
-            
+
             var pOSMap = {};
             var pOSNumber = 0;
             var pOSs = [];


### PR DESCRIPTION
原本的GBK编码的regex不能正确的替换data.prettyQuery里面的“·”符号，导致每次查询单词的结果都很怪异，文件编码设置为UTF-8就正常了
